### PR TITLE
add gcode analysis to take the estimated total print time from gcode

### DIFF
--- a/octoprint_m73etaoverride/__init__.py
+++ b/octoprint_m73etaoverride/__init__.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 import octoprint.plugin
 import re
 from octoprint.printer.estimation import PrintTimeEstimator
+from octoprint.filemanager.analysis import GcodeAnalysisQueue
 
 m73time = None
 
@@ -43,6 +44,19 @@ class M73PrintTimeEstimator(PrintTimeEstimator):
 
 def m73_create_estimator_factory(*args, **kwargs):
     return M73PrintTimeEstimator
+  
+class M73AnalysisQueue(GcodeAnalysisQueue):
+  def _do_analysis(self, high_priority=False):
+    results = super(M73AnalysisQueue, self)._do_analysis(high_priority=high_priority)
+    for line in open(self._current.absolute_path):
+      m = re.match('M73.*R(\d+)', line)
+      if m:
+        results['estimatedPrintTime'] = int(m.group(1))*60
+        break
+    return results
+
+def m73_gcode_analysis_queue(*args, **kwargs):
+  return dict(gcode=lambda finished_callback: M73AnalysisQueue(finished_callback))
 
 __plugin_name__ = "M73 ETA Override"
 __plugin_pythoncompat__ = ">=2.7,<4"
@@ -55,5 +69,6 @@ def __plugin_load__():
   __plugin_hooks__ = {
     "octoprint.comm.protocol.gcode.sent": __plugin_implementation__.handle_m73,
     "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information,
-    "octoprint.printer.estimation.factory": m73_create_estimator_factory
+    "octoprint.printer.estimation.factory": m73_create_estimator_factory,
+    "octoprint.filemanager.analysis.factory": m73_gcode_analysis_queue
   }


### PR DESCRIPTION
hey! it would have been nice if you had taken a look at the puill requests in the original repo, as i submitted one that would also make the total estimated print time (shown before the print starts) be pulled from the M73 commands in the gcode.

no worries though, cause here's the same pull request again :)